### PR TITLE
Implement dynamic user level calculation and leaderboard rendering

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,34 +1,50 @@
-import { useState } from 'react';
-import { Link, useLocation } from 'wouter';
-import { useAuth } from '../hooks/useAuth';
-import { Button } from '../components/ui/button';
-import { 
+import { useState } from "react";
+import { Link, useLocation } from "wouter";
+import { useAuth } from "../hooks/useAuth";
+import { Button } from "../components/ui/button";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from '../components/ui/dropdown-menu';
-import { Avatar, AvatarImage, AvatarFallback } from '../components/ui/avatar';
-import { Sheet, SheetContent, SheetTrigger } from '../components/ui/sheet';
-import { Leaf, Menu, User, LogOut, Settings, Award } from 'lucide-react';
+} from "../components/ui/dropdown-menu";
+import { Avatar, AvatarImage, AvatarFallback } from "../components/ui/avatar";
+import { Sheet, SheetContent, SheetTrigger } from "../components/ui/sheet";
+import {
+  Leaf,
+  Menu,
+  User,
+  LogOut,
+  Settings,
+  Award,
+  UserLock,
+} from "lucide-react";
 
 const Header = () => {
-  const [location] = useLocation();
+  const [location, setLocation] = useLocation();
   const { user, isAuthenticated, logout } = useAuth();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
+  function getUserLevel(points) {
+    if (points >= 1000) return "Eco Master";
+    if (points >= 500) return "Eco Champion";
+    if (points >= 200) return "Eco Warrior";
+    if (points >= 50) return "Eco Explorer";
+    return "Beginner";
+  }
+
   const navigationItems = [
-    { name: 'Home', href: '/' },
-    { name: 'Classify Waste', href: '/classify' },
-    { name: 'Campaigns', href: '/campaigns' },
-    { name: 'Blog', href: '/blog' },
-    { name: 'Leaderboard', href: '/leaderboard' },
+    { name: "Home", href: "/" },
+    { name: "Classify Waste", href: "/classify" },
+    { name: "Campaigns", href: "/campaigns" },
+    { name: "Blog", href: "/blog" },
+    { name: "Leaderboard", href: "/leaderboard" },
   ];
 
   // Add admin navigation for admin users
-  if (user?.role === 'admin') {
-    navigationItems.push({ name: 'Admin', href: '/admin' });
+  if (user?.role === "admin") {
+    navigationItems.push({ name: "Admin", href: "/admin" });
   }
 
   const isActive = (href) => location === href;
@@ -36,6 +52,7 @@ const Header = () => {
   const handleLogout = () => {
     logout();
     setMobileMenuOpen(false);
+    setLocation("/");
   };
 
   return (
@@ -49,16 +66,18 @@ const Header = () => {
               <span className="text-xl font-bold text-gray-900">EcoWise</span>
             </div>
           </Link>
-          
+
           {/* Desktop Navigation */}
           <div className="hidden md:flex items-center space-x-8">
             {navigationItems.map((item) => (
               <Link key={item.name} href={item.href}>
-                <span className={`font-medium transition-colors cursor-pointer ${
-                  isActive(item.href) 
-                    ? 'text-primary' 
-                    : 'text-gray-700 hover:text-primary'
-                }`}>
+                <span
+                  className={`font-medium transition-colors cursor-pointer ${
+                    isActive(item.href)
+                      ? "text-primary"
+                      : "text-gray-700 hover:text-primary"
+                  }`}
+                >
                   {item.name}
                 </span>
               </Link>
@@ -80,11 +99,17 @@ const Header = () => {
                 {/* User Menu */}
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="relative h-10 w-10 rounded-full">
+                    <Button
+                      variant="ghost"
+                      className="relative h-10 w-10 rounded-full"
+                    >
                       <Avatar className="h-10 w-10">
-                        <AvatarImage src={user?.profileImage} alt={user?.username} />
+                        <AvatarImage
+                          src={user?.profileImage}
+                          alt={user?.username}
+                        />
                         <AvatarFallback>
-                          {user?.username?.charAt(0).toUpperCase() || 'U'}
+                          {user?.username?.charAt(0).toUpperCase() || "U"}
                         </AvatarFallback>
                       </Avatar>
                     </Button>
@@ -97,7 +122,7 @@ const Header = () => {
                           {user?.email}
                         </p>
                         <p className="text-xs text-primary font-medium">
-                          Level: {user?.level}
+                          Level: {getUserLevel(user?.ecoPoints || 0)}
                         </p>
                       </div>
                     </div>
@@ -108,7 +133,7 @@ const Header = () => {
                         Profile
                       </Link>
                     </DropdownMenuItem>
-                    {user?.role === 'admin' && (
+                    {user?.role === "admin" && (
                       <DropdownMenuItem asChild>
                         <Link href="/admin">
                           <Settings className="mr-2 h-4 w-4" />
@@ -127,7 +152,10 @@ const Header = () => {
             ) : (
               <div className="flex items-center space-x-3">
                 <Link href="/login">
-                  <Button variant="outline" className="text-primary border-primary hover:bg-primary hover:text-white">
+                  <Button
+                    variant="outline"
+                    className="text-primary border-primary hover:bg-primary hover:text-white"
+                  >
                     Login
                   </Button>
                 </Link>
@@ -139,7 +167,7 @@ const Header = () => {
               </div>
             )}
           </div>
-          
+
           {/* Mobile menu button */}
           <div className="md:hidden">
             <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
@@ -161,14 +189,17 @@ const Header = () => {
                     <div className="bg-gray-50 p-4 rounded-lg">
                       <div className="flex items-center space-x-3">
                         <Avatar className="h-10 w-10">
-                          <AvatarImage src={user?.profileImage} alt={user?.username} />
+                          <AvatarImage
+                            src={user?.profileImage}
+                            alt={user?.username}
+                          />
                           <AvatarFallback>
-                            {user?.username?.charAt(0).toUpperCase() || 'U'}
+                            {user?.username?.charAt(0).toUpperCase() || "U"}
                           </AvatarFallback>
                         </Avatar>
                         <div>
                           <p className="font-medium">{user?.username}</p>
-                          <p className="text-sm text-gray-600">{user?.level}</p>
+                          <p className="text-sm text-gray-600">{getUserLevel(user?.ecoPoints || 0)}</p>
                           <div className="flex items-center space-x-1 mt-1">
                             <Award className="h-3 w-3 text-amber-600" />
                             <span className="text-xs text-amber-700">
@@ -179,16 +210,16 @@ const Header = () => {
                       </div>
                     </div>
                   )}
-                  
+
                   {/* Navigation */}
                   <nav className="space-y-2">
                     {navigationItems.map((item) => (
                       <Link key={item.name} href={item.href}>
-                        <div 
+                        <div
                           className={`block py-3 px-4 rounded-lg font-medium transition-colors cursor-pointer ${
                             isActive(item.href)
-                              ? 'bg-primary text-white'
-                              : 'text-gray-700 hover:bg-gray-100'
+                              ? "bg-primary text-white"
+                              : "text-gray-700 hover:bg-gray-100"
                           }`}
                           onClick={() => setMobileMenuOpen(false)}
                         >
@@ -197,14 +228,14 @@ const Header = () => {
                       </Link>
                     ))}
                   </nav>
-                  
+
                   {/* Auth buttons */}
                   <div className="pt-4 border-t space-y-3">
                     {isAuthenticated ? (
                       <>
                         <Link href="/profile">
-                          <Button 
-                            variant="outline" 
+                          <Button
+                            variant="outline"
                             className="w-full justify-start"
                             onClick={() => setMobileMenuOpen(false)}
                           >
@@ -212,10 +243,10 @@ const Header = () => {
                             Profile
                           </Button>
                         </Link>
-                        {user?.role === 'admin' && (
+                        {user?.role === "admin" && (
                           <Link href="/admin">
-                            <Button 
-                              variant="outline" 
+                            <Button
+                              variant="outline"
                               className="w-full justify-start"
                               onClick={() => setMobileMenuOpen(false)}
                             >
@@ -224,8 +255,8 @@ const Header = () => {
                             </Button>
                           </Link>
                         )}
-                        <Button 
-                          variant="outline" 
+                        <Button
+                          variant="outline"
                           className="w-full justify-start text-red-600 border-red-200 hover:bg-red-50"
                           onClick={handleLogout}
                         >
@@ -236,8 +267,8 @@ const Header = () => {
                     ) : (
                       <>
                         <Link href="/login">
-                          <Button 
-                            variant="outline" 
+                          <Button
+                            variant="outline"
                             className="w-full"
                             onClick={() => setMobileMenuOpen(false)}
                           >
@@ -245,7 +276,7 @@ const Header = () => {
                           </Button>
                         </Link>
                         <Link href="/register">
-                          <Button 
+                          <Button
                             className="w-full bg-primary hover:bg-primary/90"
                             onClick={() => setMobileMenuOpen(false)}
                           >

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -77,8 +77,6 @@ export const AuthProvider = ({ children }) => {
       localStorage.setItem("token", response.token);
       localStorage.setItem("user", JSON.stringify(response.user));
 
-      console.log("🔐 Login response:", response);
-
       dispatch({
         type: "LOGIN_SUCCESS",
         payload: response,

--- a/client/src/pages/WasteClassification.jsx
+++ b/client/src/pages/WasteClassification.jsx
@@ -11,6 +11,7 @@ import { format } from 'date-fns';
 const WasteClassification = () => {
   const { data: classifications = [], isLoading } = useQuery({
     queryKey: ['/api/waste-classifications'],
+    queryFn: () => wasteService.getClassifications(),
     staleTime: 2 * 60 * 1000, // 2 minutes
   });
 

--- a/server/app.js
+++ b/server/app.js
@@ -12,6 +12,8 @@ import wasteRoutes from "./routes/wasteRoutes.js";
 import ecoPointsRoutes from "./routes/ecopoints.js";
 import profileRoutes from './routes/profileRoutes.js';
 import leaderboardRoutes from './routes/leaderboardRoutes.js';
+import userRoutes from './routes/users.js';
+import statsRoutes from "./routes/stats.js";
 
 import dotenv from 'dotenv';
 dotenv.config();
@@ -45,6 +47,8 @@ app.use("/api/ecopoints", express.json(), ecoPointsRoutes);
 app.use("/api/waste", express.json(), wasteRoutes);
 app.use('/api/profile', express.json(), profileRoutes);
 app.use('/api/leaderboard', express.json(), leaderboardRoutes);
+app.use('/api/users', express.json(), userRoutes);
+app.use("/api/stats", express.json(), statsRoutes);
 
 
 // Error handling middleware

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -11,3 +11,16 @@ export const getMyProfile = async (req, res) => {
     res.status(500).json({ message: "Error fetching profile" });
   }
 };
+
+export const getProfile = async (req, res) => {
+  try {
+    // req.user should be set by your protect middleware
+    const user = await User.findById(req.user._id).select('-password');
+    if (!user) {
+      return res.status(404).json({ success: false, message: 'User not found.' });
+    }
+    res.json({ success: true, data: user });
+  } catch (error) {
+    res.status(500).json({ success: false, message: 'Server error.' });
+  }
+};

--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -1,0 +1,46 @@
+import express from "express";
+import User from "../models/User.js";
+import Classification from "../models/WasteClassification.js";
+import Campaign from "../models/Campaign.js";
+
+const router = express.Router();
+
+// GET /api/stats/global
+router.get("/global", async (req, res) => {
+  try {
+    // Total waste items classified (number of Classification docs)
+    const wasteItemsClassified = await Classification.countDocuments();
+
+    // Active users (number of User docs)
+    const activeUsers = await User.countDocuments();
+
+    // Eco points earned (sum of ecoPoints for all users)
+    const ecoPointsAgg = await User.aggregate([
+      { $group: { _id: null, total: { $sum: "$ecoPoints" } } }
+    ]);
+    const ecoPointsEarned = ecoPointsAgg[0]?.total || 0;
+
+    res.json({ wasteItemsClassified, activeUsers, ecoPointsEarned });
+  } catch (err) {
+    res.status(500).json({ message: "Error getting global stats" });
+  }
+});
+
+// GET /api/stats/cta
+router.get("/cta", async (req, res) => {
+  try {
+    const activeUsers = await User.countDocuments();
+    const itemsClassified = await Classification.countDocuments();
+    const communities = await Campaign.countDocuments();
+    const pointsAgg = await User.aggregate([
+      { $group: { _id: null, total: { $sum: "$ecoPoints" } } }
+    ]);
+    const pointsEarned = pointsAgg[0]?.total || 0;
+
+    res.json({ activeUsers, itemsClassified, communities, pointsEarned });
+  } catch (err) {
+    res.status(500).json({ message: "Error getting CTA stats" });
+  }
+});
+
+export default router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,8 +1,41 @@
 import express from "express";
-import { getMyProfile } from "../controllers/userController.js";
+import { getMyProfile ,getProfile } from "../controllers/userController.js";
 import { protect } from "../middleware/auth.js";
+import User from "../models/User.js";
 const router = express.Router();
 
+function getUserLevel(points) {
+  if (points >= 1000) return "Eco Master";
+  if (points >= 500) return "Eco Champion";
+  if (points >= 200) return "Eco Warrior";
+  if (points >= 50) return "Eco Explorer";
+  return "Beginner";
+}
+
 router.get("/me", protect, getMyProfile);
+
+router.get('/profile', protect, getProfile);
+
+router.get("/leaderboard", async (req, res) => {
+  try {
+    const topUsers = await User.find({})
+      .sort({ ecoPoints: -1 })
+      .limit(10)
+      .select("username ecoPoints"); // Only select existing fields
+
+    const leaderboard = topUsers.map(u => ({
+      id: u._id,
+      username: u.username,
+      ecoPoints: u.ecoPoints || 0,
+      level: getUserLevel(u.ecoPoints || 0),
+    }));
+
+    res.json(leaderboard);
+  } catch (err) {
+    console.error("Leaderboard error:", err);
+    res.status(500).json({ message: "Error getting leaderboard" });
+  }
+});
+
 
 export default router;


### PR DESCRIPTION
- Calculate user level from ecoPoints throughout the app (no level field in DB)
- Fix leaderboard API to remove level field and compute level on backend
- Update Home and Leaderboard pages to render top 3 users podium style
- Center "View Full Leaderboard" button below podium on Home page
- Show user level in Header using calculated value
- Add /api/users/profile endpoint for current user info
- Fix WasteClassification stats and history rendering from API data